### PR TITLE
[Feat] Add Horses

### DIFF
--- a/programs/solciv/src/instructions/city.rs
+++ b/programs/solciv/src/instructions/city.rs
@@ -57,6 +57,7 @@ pub fn add_to_production_queue(
                     settlers_count * Unit::get_resource_cost(*unit_type)
                 }
                 UnitType::Swordsman => Unit::get_resource_cost(*unit_type),
+                UnitType::Horseman => Unit::get_resource_cost(*unit_type),
                 _ => 0, // No resource cost for other unit types
             }
         }
@@ -67,6 +68,7 @@ pub fn add_to_production_queue(
         let resource_type = match &item {
             ProductionItem::Unit(UnitType::Settler) => &mut player_account.resources.food,
             ProductionItem::Unit(UnitType::Swordsman) => &mut player_account.resources.iron,
+            ProductionItem::Unit(UnitType::Horseman) => &mut player_account.resources.horses,
             // can this really happen?
             _ => return err!(CityError::InvalidItem),
         };

--- a/programs/solciv/src/instructions/game.rs
+++ b/programs/solciv/src/instructions/game.rs
@@ -31,15 +31,15 @@ fn reset_units_movement_range(units: &mut [Unit]) {
     }
 }
 
-fn calculate_resources(player_account: &Player) -> (i32, u32, u32, u32, u32, u32) {
+fn calculate_resources(player_account: &Player) -> (i32, u32, u32, u32, u32, u32, u32) {
     // Calculate resources yielded by cities and tiles.
-    // This function will return a tuple (gold, food, wood, stone, iron, science).
-    let mut resources: (i32, u32, u32, u32, u32, u32) = (0, 0, 0, 0, 0, 0);
+    // This function will return a tuple (gold, food, wood, stone, iron, horses, science).
+    let mut resources: (i32, u32, u32, u32, u32, u32, u32) = (0, 0, 0, 0, 0, 0, 0);
 
     for city in &player_account.cities {
         resources.0 += city.gold_yield as i32;
         resources.1 += city.food_yield;
-        resources.5 += city.science_yield;
+        resources.6 += city.science_yield;
     }
 
     for tile in &player_account.tiles {
@@ -48,6 +48,7 @@ fn calculate_resources(player_account: &Player) -> (i32, u32, u32, u32, u32, u32
             TileType::StoneQuarry => resources.3 += 2,
             TileType::Farm => resources.1 += 2,
             TileType::IronMine => resources.4 += 2,
+            TileType::Pasture => resources.5 += 2,
         }
     }
 
@@ -229,11 +230,11 @@ pub fn end_turn(ctx: Context<EndTurn>) -> Result<()> {
     reset_units_movement_range(&mut ctx.accounts.player_account.units);
 
     // Calculate and update player's resources
-    let (gold, food, wood, stone, iron, science) =
+    let (gold, food, wood, stone, iron, horses, science) =
         calculate_resources(&ctx.accounts.player_account);
     ctx.accounts
         .player_account
-        .update_resources(gold, food, wood, stone, iron)?;
+        .update_resources(gold, food, wood, stone, iron, horses)?;
 
     let player_account = &mut ctx.accounts.player_account;
 

--- a/programs/solciv/src/instructions/player.rs
+++ b/programs/solciv/src/instructions/player.rs
@@ -16,6 +16,7 @@ pub fn initialize_player(ctx: Context<InitializePlayer>) -> Result<()> {
         stone: 0,
         iron: 0,
         gems: 0,
+        horses: 0,
     };
     // player starts with 3 units: Settler, Builder, Warrior
     ctx.accounts.player_account.units = vec![

--- a/programs/solciv/src/state/game_state.rs
+++ b/programs/solciv/src/state/game_state.rs
@@ -52,6 +52,7 @@ impl Player {
         wood: u32,
         stone: u32,
         iron: u32,
+        horses: u32,
     ) -> Result<()> {
         self.resources.gold = self.resources.gold.checked_add(gold).unwrap_or({
             if gold > 0 {
@@ -64,6 +65,7 @@ impl Player {
         self.resources.wood = self.resources.wood.checked_add(wood).unwrap_or(u32::MAX);
         self.resources.stone = self.resources.stone.checked_add(stone).unwrap_or(u32::MAX);
         self.resources.iron = self.resources.iron.checked_add(iron).unwrap_or(u32::MAX);
+        self.resources.horses = self.resources.horses.checked_add(horses).unwrap_or(u32::MAX);
         Ok(())
     }
 

--- a/programs/solciv/src/state/game_state.rs
+++ b/programs/solciv/src/state/game_state.rs
@@ -108,19 +108,21 @@ impl Player {
 
     pub fn can_research(&self, tech: &TechnologyType) -> bool {
         let prev_tech = match tech {
-            TechnologyType::Archery => return true,
+            TechnologyType::AnimalHusbandry | TechnologyType::Writing | TechnologyType::Agriculture => {
+                return true
+            },
+            TechnologyType::Archery => TechnologyType::AnimalHusbandry,
+            TechnologyType::HorsebackRiding => TechnologyType::Archery,
             TechnologyType::IronWorking => TechnologyType::Archery,
             TechnologyType::MedievalWarfare => TechnologyType::IronWorking,
             TechnologyType::Gunpowder => TechnologyType::MedievalWarfare,
             TechnologyType::Ballistics => TechnologyType::Gunpowder,
             TechnologyType::TanksAndArmor => TechnologyType::Ballistics,
-            TechnologyType::Writing => return true,
             TechnologyType::Education => TechnologyType::Writing,
             TechnologyType::Economics => TechnologyType::Education,
             TechnologyType::Academia => TechnologyType::Economics,
             TechnologyType::Astronomy => TechnologyType::Academia,
             TechnologyType::Capitalism => TechnologyType::Astronomy,
-            TechnologyType::Agriculture => return true,
             TechnologyType::Construction => TechnologyType::Agriculture,
             TechnologyType::Industrialization => TechnologyType::Construction,
             TechnologyType::ElectricalPower => TechnologyType::Industrialization,

--- a/programs/solciv/src/state/resources_economy.rs
+++ b/programs/solciv/src/state/resources_economy.rs
@@ -8,6 +8,7 @@ pub struct Resources {
     pub stone: u32,
     pub iron: u32,
     pub gems: u32,
+    pub horses: u32,
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
@@ -23,6 +24,7 @@ pub enum TileType {
     StoneQuarry,
     Farm,
     IronMine,
+    Pasture,
 }
 
 impl Tile {

--- a/programs/solciv/src/state/science.rs
+++ b/programs/solciv/src/state/science.rs
@@ -2,7 +2,9 @@ use anchor_lang::prelude::*;
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, PartialEq, Debug)]
 pub enum TechnologyType {
+    AnimalHusbandry,
     Archery,
+    HorsebackRiding,
     IronWorking,
     MedievalWarfare,
     Gunpowder,
@@ -24,7 +26,9 @@ pub enum TechnologyType {
 impl TechnologyType {
     pub fn get_cost(tech_type: &TechnologyType) -> u32 {
         match tech_type {
-            TechnologyType::Archery => 15,
+            TechnologyType::AnimalHusbandry => 7,
+            TechnologyType::Archery => 10,
+            TechnologyType::HorsebackRiding => 20,
             TechnologyType::IronWorking => 21,
             TechnologyType::MedievalWarfare => 30,
             TechnologyType::Gunpowder => 42,

--- a/programs/solciv/src/state/units_combat.rs
+++ b/programs/solciv/src/state/units_combat.rs
@@ -33,6 +33,7 @@ pub enum UnitType {
     Musketman,
     Rifleman,
     Tank,
+    Horseman,
 }
 
 impl Unit {
@@ -93,6 +94,7 @@ impl Unit {
             UnitType::Warrior => (false, 100, 8, 2, 0, 20, 200, 0, 0),
             UnitType::Archer => (true, 100, 10, 2, 0, 20, 200, 0, 1),
             UnitType::Swordsman => (false, 100, 14, 2, 0, 30, 240, 10, 1),
+            UnitType::Horseman => (false, 100, 14, 3, 0, 30, 280, 10, 2),
             UnitType::Crossbowman => (true, 100, 24, 2, 0, 40, 240, 0, 2),
             UnitType::Musketman => (true, 100, 32, 2, 0, 50, 360, 0, 2),
             UnitType::Rifleman => (true, 100, 40, 3, 0, 60, 420, 0, 4),
@@ -242,6 +244,7 @@ impl UnitType {
         match self {
             UnitType::Settler | UnitType::Builder | UnitType::Warrior => true, // No tech required
             UnitType::Archer => researched_technologies.contains(&TechnologyType::Archery),
+            UnitType::Horseman => researched_technologies.contains(&TechnologyType::HorsebackRiding),
             UnitType::Swordsman => researched_technologies.contains(&TechnologyType::IronWorking),
             UnitType::Crossbowman => {
                 researched_technologies.contains(&TechnologyType::MedievalWarfare)


### PR DESCRIPTION
The goal of this PR is to add horses, a new strategic resource used for building cavalry units. The introduction of horses is important as it allows for the following game mechanics, which are implemented in this PR:
- The `AnimalHusbandry` and `HorsebackRiding` techs
- `Pastures` as a tile improvement
- The `Horseman` unit

Important changes made to the existing codebase include:
- `AnimalHusbandry` is now a starter tech. It has a research cost of 7 and unlocks the `Pasture` improvement for horses
- A player must research `AnimalHusbandry` to unlock the ability to research `Archery`. The research cost for `Archery` has been reduced from 15 to 10 to reflect this change
- A player must research `Archery` to unlock `HoresbackRiding`. `HorsebackRiding` has a research cost of 20 and unlocks the ability to create the `Horseman` unit. To build a `Horseman`, a player needs a source of horses. This unit has a movement cost of 3, which can be tweaked based on playtesting and user feedback

The introduction of horses, as well as the new techs, units, and improvements that follow, enables the game to explore the idea of cavalry units and adds an important strategic resource to the game