### PR TITLE
Add Upgrade unit feature

### DIFF
--- a/programs/solciv/src/consts.rs
+++ b/programs/solciv/src/consts.rs
@@ -4,8 +4,9 @@ pub const MAX_BUILDINGS: u8 = 20;
 pub const MAX_UPGRADED_TILES: u8 = 100;
 pub const MAX_PRODUCTION_QUEUE: u8 = 5;
 pub const MAP_BOUND: u8 = 20;
+
 pub const GEMS_PER_KILL: u8 = 1;
 pub const GEMS_PER_CITY_DESTROYED: u8 = 50;
-pub const EXP_FOR_LEVEL_1: u8 = 10;
-pub const EXP_FOR_LEVEL_2: u8 = 30;
-pub const EXP_FOR_LEVEL_3: u8 = 45;
+
+pub const EXP_THRESHOLDS: [u8; 3] = [10, 30, 45];
+pub const EXP_PER_ATTACK: u8 = 3;

--- a/programs/solciv/src/consts.rs
+++ b/programs/solciv/src/consts.rs
@@ -6,3 +6,6 @@ pub const MAX_PRODUCTION_QUEUE: u8 = 5;
 pub const MAP_BOUND: u8 = 20;
 pub const GEMS_PER_KILL: u8 = 1;
 pub const GEMS_PER_CITY_DESTROYED: u8 = 50;
+pub const EXP_FOR_LEVEL_1: u8 = 10;
+pub const EXP_FOR_LEVEL_2: u8 = 30;
+pub const EXP_FOR_LEVEL_3: u8 = 45;

--- a/programs/solciv/src/errors.rs
+++ b/programs/solciv/src/errors.rs
@@ -38,10 +38,10 @@ pub enum UnitError {
     #[msg("Not enough of food to heal the unit")]
     NotEnoughResources,
 
-    #[msg("Max level reached, cannot upgrade unit level")]
+    #[msg("Max level reached")]
     MaxLevelReached,
 
-    #[msg("Not enought experience to upgrade the unit level")]
+    #[msg("Not enought experience to level up unit")]
     NotEnoughExp,
 }
 

--- a/programs/solciv/src/errors.rs
+++ b/programs/solciv/src/errors.rs
@@ -37,6 +37,12 @@ pub enum UnitError {
 
     #[msg("Not enough of food to heal the unit")]
     NotEnoughResources,
+
+    #[msg("Max level reached, cannot upgrade unit level")]
+    MaxLevelReached,
+
+    #[msg("Not enought experience to upgrade the unit level")]
+    NotEnoughExp,
 }
 
 #[error_code]

--- a/programs/solciv/src/instructions/city.rs
+++ b/programs/solciv/src/instructions/city.rs
@@ -58,7 +58,7 @@ pub fn add_to_production_queue(
                     // @todo: this now requires Population > 1
                     // @todo: decrease population when the settler is recruited
                     0
-                },
+                }
                 UnitType::Swordsman => Unit::get_resource_cost(*unit_type),
                 UnitType::Horseman => Unit::get_resource_cost(*unit_type),
                 _ => 0, // No resource cost for other unit types

--- a/programs/solciv/src/instructions/unit.rs
+++ b/programs/solciv/src/instructions/unit.rs
@@ -91,7 +91,7 @@ pub fn upgrade_unit(ctx: Context<UpgradeUnit>, unit_id: u32) -> Result<()> {
     let unit_level = units[unit_idx].level;
     let unit_health = units[unit_idx].health;
     let unit_movement_range = units[unit_idx].movement_range;
-    
+
     // unit dont have movement range
     if unit_movement_range == 0 {
         return err!(UnitError::NoMovementPoints);
@@ -302,7 +302,7 @@ pub fn attack_unit(ctx: Context<AttackUnit>, attacker_id: u32, defender_id: u32)
     }
 
     attacker.attack_unit(defender, None)?;
-    
+
     if !defender.is_alive {
         ctx.accounts.player_account.resources.gems = ctx
             .accounts
@@ -368,7 +368,7 @@ pub fn attack_city(ctx: Context<AttackCity>, attacker_id: u32, city_id: u32) -> 
 
         attacker.attack_city(target_city)?;
         attacker.movement_range = 0;
-        
+
         let exp_to_gain = calculate_exp_amount(attacker.level, attacker.experience, 3);
         attacker.experience = exp_to_gain;
 

--- a/programs/solciv/src/instructions/unit.rs
+++ b/programs/solciv/src/instructions/unit.rs
@@ -347,30 +347,11 @@ pub fn attack_city(ctx: Context<AttackCity>, attacker_id: u32, city_id: u32) -> 
         return err!(UnitError::OutOfAttackRange);
     }
 
-    let city_was_destroyed = {
-        let target_city = ctx
-            .accounts
-            .npc_account
-            .cities
-            .iter_mut()
-            .find(|c| c.city_id == city_id)
-            .ok_or(CityError::CityNotFound)?;
+    attacker.attack_city(target_city)?;
+    attacker.movement_range = 0;
+    attacker.experience = get_new_exp(attacker.level, attacker.experience, 3);
 
-        let dist_x = (attacker.x as i16 - target_city.x as i16).abs();
-        let dist_y = (attacker.y as i16 - target_city.y as i16).abs();
-        let dist = std::cmp::max(dist_x, dist_y) as u8;
-
-        if dist != 1 {
-            return err!(UnitError::OutOfAttackRange);
-        }
-
-        attacker.attack_city(target_city)?;
-        attacker.movement_range = 0;
-
-        attacker.experience = get_new_exp(attacker.level, attacker.experience, 3);
-
-        target_city.health == 0
-    };
+    let city_was_destroyed = target_city.health == 0;
 
     if city_was_destroyed {
         ctx.accounts.player_account.resources.gems = ctx

--- a/programs/solciv/src/lib.rs
+++ b/programs/solciv/src/lib.rs
@@ -4,12 +4,13 @@ mod consts;
 mod errors;
 mod instructions;
 mod state;
+mod utils;
 
 use crate::instructions::*;
 use crate::state::{ProductionItem, TechnologyType};
 use anchor_lang::prelude::*;
 
-declare_id!("3qoyRXbpBJDPfQYL5GUFJ2nf2YzpA8kZmXPYr4DZBmPU");
+declare_id!("8RTGhsKoX81TVW8zwZwR483WKSWjdW4eYcVkHsgsgtCr");
 
 #[program]
 pub mod solciv {
@@ -33,6 +34,10 @@ pub mod solciv {
 
     pub fn heal_unit(ctx: Context<HealUnit>, unit_id: u32) -> Result<()> {
         instructions::heal_unit(ctx, unit_id)
+    }
+
+    pub fn upgrade_unit(ctx: Context<UpgradeUnit>, unit_id: u32) -> Result<()> {
+        instructions::upgrade_unit(ctx, unit_id)
     }
 
     pub fn found_city(

--- a/programs/solciv/src/lib.rs
+++ b/programs/solciv/src/lib.rs
@@ -10,7 +10,7 @@ use crate::instructions::*;
 use crate::state::{ProductionItem, TechnologyType};
 use anchor_lang::prelude::*;
 
-declare_id!("8RTGhsKoX81TVW8zwZwR483WKSWjdW4eYcVkHsgsgtCr");
+declare_id!("3qoyRXbpBJDPfQYL5GUFJ2nf2YzpA8kZmXPYr4DZBmPU");
 
 #[program]
 pub mod solciv {

--- a/programs/solciv/src/state/units_combat.rs
+++ b/programs/solciv/src/state/units_combat.rs
@@ -1,6 +1,6 @@
 use crate::errors::*;
-use crate::utils::*;
 use crate::state::{City, TechnologyType};
+use crate::utils::*;
 use anchor_lang::prelude::*;
 
 #[derive(AnchorSerialize, AnchorDeserialize, Copy, Clone)]
@@ -94,7 +94,9 @@ impl Unit {
     ///
     /// A tuple containing values representing the base stats of the unit in the following order:
     /// `(is_ranged, health, attack, movement_range, remaining_actions, base_production_cost, base_gold_cost, base_resource_cost, maintenance_cost, experience, level)`.
-    pub fn get_base_stats(unit_type: UnitType) -> (bool, u8, u8, u8, u8, u32, u32, u32, i32, u8, u8) {
+    pub fn get_base_stats(
+        unit_type: UnitType,
+    ) -> (bool, u8, u8, u8, u8, u32, u32, u32, i32, u8, u8) {
         match unit_type {
             UnitType::Settler => (false, 100, 0, 2, 1, 20, 100, 60, 0, 0, 0),
             UnitType::Builder => (false, 100, 0, 2, 1, 20, 100, 0, 0, 0, 0),
@@ -194,7 +196,7 @@ impl Unit {
             // if attacker kill defender - he will gain 5 (2+3) XP
             let exp_to_gain = calculate_exp_amount(self.level, self.experience, 2);
             self.experience = exp_to_gain;
-            
+
             msg!("Defender is dead");
         } else {
             let exp_to_gain = calculate_exp_amount(defender.level, defender.experience, 3);
@@ -212,7 +214,6 @@ impl Unit {
         } else {
             let exp_to_gain = calculate_exp_amount(self.level, self.experience, 3);
             self.experience = exp_to_gain;
-            
 
             self.health -= taken_damage;
             msg!("Attacker HP after attack: {}", self.health);

--- a/programs/solciv/src/state/units_combat.rs
+++ b/programs/solciv/src/state/units_combat.rs
@@ -12,6 +12,7 @@ pub struct Unit {
     pub y: u8,
     pub attack: u8,
     pub health: u8,
+    pub experience: u8,
     pub movement_range: u8,
     pub remaining_actions: u8,
     pub base_production_cost: u32,
@@ -55,6 +56,7 @@ impl Unit {
             base_gold_cost,
             base_resource_cost,
             maintenance_cost,
+            experience,
         ) = Self::get_base_stats(unit_type);
 
         Self {
@@ -66,6 +68,7 @@ impl Unit {
             y,
             attack,
             health,
+            experience,
             movement_range,
             remaining_actions,
             base_production_cost,
@@ -86,19 +89,19 @@ impl Unit {
     /// ### Returns
     ///
     /// A tuple containing values representing the base stats of the unit in the following order:
-    /// `(is_ranged, health, attack, movement_range, remaining_actions, base_production_cost, base_gold_cost, base_resource_cost, maintenance_cost)`.
-    pub fn get_base_stats(unit_type: UnitType) -> (bool, u8, u8, u8, u8, u32, u32, u32, i32) {
+    /// `(is_ranged, health, attack, movement_range, remaining_actions, base_production_cost, base_gold_cost, base_resource_cost, maintenance_cost, experience)`.
+    pub fn get_base_stats(unit_type: UnitType) -> (bool, u8, u8, u8, u8, u32, u32, u32, i32, u8) {
         match unit_type {
-            UnitType::Settler => (false, 100, 0, 2, 1, 20, 100, 60, 0),
-            UnitType::Builder => (false, 100, 0, 2, 1, 20, 100, 0, 0),
-            UnitType::Warrior => (false, 100, 8, 2, 0, 20, 200, 0, 0),
-            UnitType::Archer => (true, 100, 10, 2, 0, 20, 200, 0, 1),
-            UnitType::Swordsman => (false, 100, 14, 2, 0, 30, 240, 10, 1),
-            UnitType::Horseman => (false, 100, 14, 3, 0, 30, 280, 10, 2),
-            UnitType::Crossbowman => (true, 100, 24, 2, 0, 40, 240, 0, 2),
-            UnitType::Musketman => (true, 100, 32, 2, 0, 50, 360, 0, 2),
-            UnitType::Rifleman => (true, 100, 40, 3, 0, 60, 420, 0, 4),
-            UnitType::Tank => (true, 100, 50, 4, 0, 80, 500, 0, 7),
+            UnitType::Settler => (false, 100, 0, 2, 1, 20, 100, 60, 0, 0),
+            UnitType::Builder => (false, 100, 0, 2, 1, 20, 100, 0, 0, 0),
+            UnitType::Warrior => (false, 100, 8, 2, 0, 20, 200, 0, 0, 0),
+            UnitType::Archer => (true, 100, 10, 2, 0, 20, 200, 0, 1, 0),
+            UnitType::Swordsman => (false, 100, 14, 2, 0, 30, 240, 10, 1, 0),
+            UnitType::Horseman => (false, 100, 14, 3, 0, 30, 280, 10, 2, 0),
+            UnitType::Crossbowman => (true, 100, 24, 2, 0, 40, 240, 0, 2, 0),
+            UnitType::Musketman => (true, 100, 32, 2, 0, 50, 360, 0, 2, 0),
+            UnitType::Rifleman => (true, 100, 40, 3, 0, 60, 420, 0, 4, 0),
+            UnitType::Tank => (true, 100, 50, 4, 0, 80, 500, 0, 7, 0),
         }
     }
 
@@ -120,6 +123,10 @@ impl Unit {
 
     pub fn get_maintenance_cost(unit_type: UnitType) -> i32 {
         Unit::get_base_stats(unit_type).8
+    }
+
+    pub fn get_expereince(unit_type: UnitType) -> u8 {
+        Unit::get_base_stats(unit_type).9
     }
 
     fn can_attack(&self) -> bool {

--- a/programs/solciv/src/utils.rs
+++ b/programs/solciv/src/utils.rs
@@ -1,0 +1,14 @@
+use crate::consts::*;
+
+pub fn calculate_exp_amount(current_level: u8, current_exp: u8, exp_amount: u8) -> u8 {
+  const MAX_EXP_LEVELS: [u8; 3] = [EXP_FOR_LEVEL_1, EXP_FOR_LEVEL_2, EXP_FOR_LEVEL_3];
+  
+  let max_exp = MAX_EXP_LEVELS[current_level as usize];
+  let new_exp = current_exp + exp_amount;
+
+  if new_exp >= max_exp - exp_amount {
+      max_exp
+  } else {
+      new_exp
+  }
+}

--- a/programs/solciv/src/utils.rs
+++ b/programs/solciv/src/utils.rs
@@ -1,14 +1,14 @@
 use crate::consts::*;
 
 pub fn calculate_exp_amount(current_level: u8, current_exp: u8, exp_amount: u8) -> u8 {
-  const MAX_EXP_LEVELS: [u8; 3] = [EXP_FOR_LEVEL_1, EXP_FOR_LEVEL_2, EXP_FOR_LEVEL_3];
-  
-  let max_exp = MAX_EXP_LEVELS[current_level as usize];
-  let new_exp = current_exp + exp_amount;
+    const MAX_EXP_LEVELS: [u8; 3] = [EXP_FOR_LEVEL_1, EXP_FOR_LEVEL_2, EXP_FOR_LEVEL_3];
 
-  if new_exp >= max_exp - exp_amount {
-      max_exp
-  } else {
-      new_exp
-  }
+    let max_exp = MAX_EXP_LEVELS[current_level as usize];
+    let new_exp = current_exp + exp_amount;
+
+    if new_exp >= max_exp - exp_amount {
+        max_exp
+    } else {
+        new_exp
+    }
 }

--- a/programs/solciv/src/utils.rs
+++ b/programs/solciv/src/utils.rs
@@ -1,14 +1,20 @@
 use crate::consts::*;
 
-pub fn calculate_exp_amount(current_level: u8, current_exp: u8, exp_amount: u8) -> u8 {
-    const MAX_EXP_LEVELS: [u8; 3] = [EXP_FOR_LEVEL_1, EXP_FOR_LEVEL_2, EXP_FOR_LEVEL_3];
+pub fn get_new_exp(current_level: u8, current_exp: u8, exp_amount: u8) -> u8 {
+    // Adjust current_level to match array indexing and check if max level was reached
+    let adjusted_level = current_level.saturating_sub(1);
+    if adjusted_level as usize >= EXP_THRESHOLDS.len() {
+        return current_exp;
+    }
 
-    let max_exp = MAX_EXP_LEVELS[current_level as usize];
-    let new_exp = current_exp + exp_amount;
+    let max_exp = EXP_THRESHOLDS[adjusted_level as usize];
+    let new_exp = current_exp.saturating_add(exp_amount);
 
-    if new_exp >= max_exp - exp_amount {
+    if new_exp >= max_exp {
+        // Cap the experience at the max for the current level
         max_exp
     } else {
+        // Otherwise, just add the new experience
         new_exp
     }
 }

--- a/programs/solciv/src/utils.rs
+++ b/programs/solciv/src/utils.rs
@@ -1,13 +1,11 @@
 use crate::consts::*;
 
 pub fn get_new_exp(current_level: u8, current_exp: u8, exp_amount: u8) -> u8 {
-    // Adjust current_level to match array indexing and check if max level was reached
-    let adjusted_level = current_level.saturating_sub(1);
-    if adjusted_level as usize >= EXP_THRESHOLDS.len() {
-        return current_exp;
+    if current_level as usize >= EXP_THRESHOLDS.len() {
+        return 0;
     }
 
-    let max_exp = EXP_THRESHOLDS[adjusted_level as usize];
+    let max_exp = EXP_THRESHOLDS[current_level as usize];
     let new_exp = current_exp.saturating_add(exp_amount);
 
     if new_exp >= max_exp {


### PR DESCRIPTION
There are 3 levels for each unit (except Settler and Builder):

Level 1 - require 10 experience points 
Level 2 - require 30 experience points 
Level 3 - require 45 experience points 

Each level upgrade will increase level by 1, heal 30 HP and increase attack by 2 and set movement range to 0.

After unit reached required number of experience for level, he cannt get more points, until user upgrade it.

Each unit will get 3 points if it stay in defense, 5 points if it kill the enemy in current attack, 3 points for regular attack  and 3 points for city attack.
