### PR TITLE
GIB💎WORK Bounty - Add city borders expansion

### DIFF
--- a/programs/solciv/src/instructions/game.rs
+++ b/programs/solciv/src/instructions/game.rs
@@ -43,10 +43,22 @@ fn find_adjacent_tiles(tiles: &Vec<TileCoordinate>) -> Vec<TileCoordinate> {
 
     for tile in tiles {
         let possible_adjacents = [
-            TileCoordinate { x: tile.x, y: tile.y.saturating_sub(1) },
-            TileCoordinate { x: tile.x, y: tile.y + 1 },
-            TileCoordinate { x: tile.x.saturating_sub(1), y: tile.y },
-            TileCoordinate { x: tile.x + 1, y: tile.y },
+            TileCoordinate {
+                x: tile.x,
+                y: tile.y.saturating_sub(1),
+            },
+            TileCoordinate {
+                x: tile.x,
+                y: tile.y + 1,
+            },
+            TileCoordinate {
+                x: tile.x.saturating_sub(1),
+                y: tile.y,
+            },
+            TileCoordinate {
+                x: tile.x + 1,
+                y: tile.y,
+            },
         ];
 
         for adj in possible_adjacents {
@@ -56,7 +68,7 @@ fn find_adjacent_tiles(tiles: &Vec<TileCoordinate>) -> Vec<TileCoordinate> {
         }
     }
 
-    return adjacent_tiles;
+    adjacent_tiles
 }
 
 fn calculate_resources(player_account: &Player) -> (i32, u32, u32, u32, u32, u32) {
@@ -339,7 +351,7 @@ pub fn end_turn(ctx: Context<EndTurn>) -> Result<()> {
         }
 
         // growth city
-        city.growth_points += city.population * 1; // 1 citizen growth points generated
+        city.growth_points += city.population; // 1 citizen growth points generated
         let points_need = 10.0 + (6.0 * city.level as f32).powf(1.3);
 
         if city.growth_points as f32 >= points_need {
@@ -350,7 +362,8 @@ pub fn end_turn(ctx: Context<EndTurn>) -> Result<()> {
 
             let clock = Clock::get()?;
             let random_factor = clock.unix_timestamp % 10;
-            city.controlled_tiles.push(adjacent_tiles[random_factor as usize]);
+            city.controlled_tiles
+                .push(adjacent_tiles[random_factor as usize]);
         }
     }
 

--- a/programs/solciv/src/instructions/game.rs
+++ b/programs/solciv/src/instructions/game.rs
@@ -379,9 +379,11 @@ pub fn end_turn(ctx: Context<EndTurn>) -> Result<()> {
 
             let adjacent_tiles = find_adjacent_tiles(&city.controlled_tiles, &all_controlled_tiles);
 
-            let clock = Clock::get()?;
-            let random_factor = clock.unix_timestamp as usize % adjacent_tiles.len();
-            city.controlled_tiles.push(adjacent_tiles[random_factor]);
+            if !adjacent_tiles.is_empty() {
+                let clock = Clock::get()?;
+                let random_factor = clock.unix_timestamp as usize % adjacent_tiles.len();
+                city.controlled_tiles.push(adjacent_tiles[random_factor]);
+            };
         }
     }
 

--- a/programs/solciv/src/state/city_buildings.rs
+++ b/programs/solciv/src/state/city_buildings.rs
@@ -23,9 +23,11 @@ pub struct City {
     pub accumulated_food: i32,
     pub housing: u32,
     pub controlled_tiles: Vec<TileCoordinate>,
+    pub level: u32,
+    pub growth_points: u32,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq)]
 pub struct TileCoordinate {
     pub x: u8,
     pub y: u8,
@@ -95,6 +97,8 @@ impl City {
             accumulated_production: 0,
             accumulated_food: 0,
             housing: 4,
+            level: 0,
+            growth_points: 0,
         }
     }
 

--- a/programs/solciv/src/state/city_buildings.rs
+++ b/programs/solciv/src/state/city_buildings.rs
@@ -27,7 +27,7 @@ pub struct City {
     pub growth_points: u32,
 }
 
-#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TileCoordinate {
     pub x: u8,
     pub y: u8,


### PR DESCRIPTION
 🤖 This pull request was created by https://app.gib.work/i/qX2fwBEg/add-city-borders-expansion 
 ⚡️ Payment for bounty is immediately sent to the contributor after merge.

# Feature Enhancement: City Expansion

At the end of each turn, the player's city will earn a Growth Point. Upon reaching a specified threshold, the city will be upgraded and automatically expand by adding a random tile to its controlled territory.

# Solution

Every time the end_turn function executes, it will accrue growth_points proportional to the population. Upon reaching the required points threshold, the find_adjacent_tiles function is triggered to identify all neighboring tiles surrounding the controlled area. Subsequently, one of these tiles is randomly selected and annexed to the city's controlled tiles.

![image](https://github.com/proxycapital/solana-civ/assets/15316761/3fb68b15-4ef7-40b1-b809-ca8276f45485)



Close issue [19](https://github.com/proxycapital/solana-civ/issues/19)